### PR TITLE
Handle non-existent blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ module.exports = (function() {
   }
 
   function parseBlock(block) {
+    if (!block) { return {}; }
     var block_object = {}, lines = block.split('\n');
     lines.forEach(function(line) {
       var data = line.split('=');


### PR DESCRIPTION
avprober blew up on a file because one of the blocks was set to "false", which is not a string and so can't be split. (File is an ogv, which github will not let me attach.) Handle this use case.
